### PR TITLE
Add support for logging basic types written by Objective-c

### DIFF
--- a/Example_Objc.xcodeproj/project.pbxproj
+++ b/Example_Objc.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1BC2E48A2192B58D00E589E3 /* CocoaDebug+Extension.m in Sources */ = {isa = PBXBuildFile; fileRef = 1BC2E4892192B58D00E589E3 /* CocoaDebug+Extension.m */; };
 		EA165F01204D2539001472C1 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = EA165F00204D2539001472C1 /* AppDelegate.m */; };
 		EA165F04204D2539001472C1 /* ViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = EA165F03204D2539001472C1 /* ViewController.m */; };
 		EA165F07204D2539001472C1 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = EA165F05204D2539001472C1 /* Main.storyboard */; };
@@ -219,6 +220,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		1BC2E4882192B58D00E589E3 /* CocoaDebug+Extension.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CocoaDebug+Extension.h"; sourceTree = "<group>"; };
+		1BC2E4892192B58D00E589E3 /* CocoaDebug+Extension.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = "CocoaDebug+Extension.m"; sourceTree = "<group>"; };
 		EA165EFC204D2539001472C1 /* Example_Objc.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example_Objc.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA165EFF204D2539001472C1 /* AppDelegate.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AppDelegate.h; sourceTree = "<group>"; };
 		EA165F00204D2539001472C1 /* AppDelegate.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = AppDelegate.m; sourceTree = "<group>"; };
@@ -528,6 +531,8 @@
 				EAB3575520F1C2FB00993661 /* CocoaDebugSettings.swift */,
 				EAB3575620F1C2FB00993661 /* CocoaDebug.h */,
 				EAB3575720F1C2FB00993661 /* CocoaDebug+Extensions.swift */,
+				1BC2E4882192B58D00E589E3 /* CocoaDebug+Extension.h */,
+				1BC2E4892192B58D00E589E3 /* CocoaDebug+Extension.m */,
 			);
 			path = Core;
 			sourceTree = "<group>";
@@ -1057,6 +1062,7 @@
 				EAB358B720F1C2FC00993661 /* Swizzling.m in Sources */,
 				EAB358AD20F1C2FC00993661 /* LogViewController.swift in Sources */,
 				EAB358A320F1C2FC00993661 /* NetworkHelper.m in Sources */,
+				1BC2E48A2192B58D00E589E3 /* CocoaDebug+Extension.m in Sources */,
 				EAB3581D20F1C2FB00993661 /* AppInfoViewController.swift in Sources */,
 				EAB358A620F1C2FC00993661 /* CustomProtocol.m in Sources */,
 				EAB358A820F1C2FC00993661 /* NetworkDetailViewController.swift in Sources */,

--- a/Example_Objc/Example_Objc-Bridging-Header.h
+++ b/Example_Objc/Example_Objc-Bridging-Header.h
@@ -4,4 +4,3 @@
 
 #import "CocoaDebug.h"
 
-

--- a/Example_Objc/PrefixHeader.pch
+++ b/Example_Objc/PrefixHeader.pch
@@ -7,13 +7,15 @@
 //
 
 #import "Example_Objc-Swift.h"
+#import "CocoaDebug+Extension.h"
 
 #pragma clang diagnostic ignored "-Wunused-value"
 
 
 //----------------- white log (default) -----------------
 #ifdef DEBUG
-#define NSLog(fmt, ...) [CocoaDebug objcLog:[[NSString stringWithUTF8String:__FILE__] lastPathComponent] :NSStringFromSelector(_cmd) :__LINE__ :(fmt, ##__VA_ARGS__) :[UIColor whiteColor]]
+
+#define NSLog(fmt, ...) [CocoaDebug objcLogWithFile:__FILE__ function:NSStringFromSelector(_cmd) line:__LINE__ color:[UIColor whiteColor] message:(fmt), ##__VA_ARGS__]
 #else
 #define NSLog(fmt, ...) nil
 #endif
@@ -21,7 +23,7 @@
 
 //----------------- red log -----------------
 #ifdef DEBUG
-#define RedLog(fmt, ...) [CocoaDebug objcLog:[[NSString stringWithUTF8String:__FILE__] lastPathComponent] :NSStringFromSelector(_cmd) :__LINE__ :(fmt, ##__VA_ARGS__) :[UIColor redColor]]
+#define RedLog(fmt, ...) [CocoaDebug objcLogWithFile:__FILE__ function:NSStringFromSelector(_cmd) line:__LINE__ color:[UIColor redColor] message:(fmt), ##__VA_ARGS__]
 #else
 #define RedLog(fmt, ...) nil
 #endif
@@ -29,7 +31,7 @@
 
 //----------------- blue log -----------------
 #ifdef DEBUG
-#define BlueLog(fmt, ...) [CocoaDebug objcLog:[[NSString stringWithUTF8String:__FILE__] lastPathComponent] :NSStringFromSelector(_cmd) :__LINE__ :(fmt, ##__VA_ARGS__) :[UIColor blueColor]]
+#define BlueLog(fmt, ...) [CocoaDebug objcLogWithFile:__FILE__ function:NSStringFromSelector(_cmd) line:__LINE__ color:[UIColor blueColor] message:(fmt), ##__VA_ARGS__]
 #else
 #define BlueLog(fmt, ...) nil
 #endif
@@ -37,7 +39,7 @@
 
 //----------------- yellow log -----------------
 #ifdef DEBUG
-#define YellowLog(fmt, ...) [CocoaDebug objcLog:[[NSString stringWithUTF8String:__FILE__] lastPathComponent] :NSStringFromSelector(_cmd) :__LINE__ :(fmt, ##__VA_ARGS__) :[UIColor yellowColor]]
+#define YellowLog(fmt, ...) [CocoaDebug objcLogWithFile:__FILE__ function:NSStringFromSelector(_cmd) line:__LINE__ color:[UIColor yellowColor] message:(fmt), ##__VA_ARGS__]
 #else
 #define YellowLog(fmt, ...) nil
 #endif

--- a/Example_Objc/ViewController.m
+++ b/Example_Objc/ViewController.m
@@ -39,7 +39,7 @@
         if (error) {
             NSLog(error.localizedDescription);
         } else {
-            NSLog(response);
+            NSLog(@"%@",response);
             NSLog(responseObject);
         }
     }];
@@ -69,7 +69,7 @@
         if(httpResponse.statusCode == 200) {
             NSError *parseError = nil;
             NSDictionary *responseDictionary = [NSJSONSerialization JSONObjectWithData:data options:0 error:&parseError];
-            BlueLog(responseDictionary);
+            BlueLog(@"%@",responseDictionary);
         }else{
             BlueLog(error.localizedDescription);
         }

--- a/Sources/Core/CocoaDebug+Extension.h
+++ b/Sources/Core/CocoaDebug+Extension.h
@@ -1,0 +1,23 @@
+//
+//  CocoaDebug+Extension.h
+//  Example_Objc
+//
+//  Created by iCeBlink on 2018/11/7.
+//  Copyright © 2018 liman. All rights reserved.
+//
+
+NS_ASSUME_NONNULL_BEGIN
+
+@class CocoaDebug;
+
+@interface CocoaDebug (Extension)
+
++ (void)objcLogWithFile:(const char *)file
+               function:(NSString *)function
+                   line:(NSUInteger)line
+                  color:(UIColor *)color
+                message:(NSString *)format, ...;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/Sources/Core/CocoaDebug+Extension.m
+++ b/Sources/Core/CocoaDebug+Extension.m
@@ -1,0 +1,35 @@
+//
+//  CocoaDebug+Extension.m
+//  Example_Objc
+//
+//  Created by iCeBlink on 2018/11/7.
+//  Copyright © 2018 liman. All rights reserved.
+//
+
+#import "CocoaDebug+Extension.h"
+
+@implementation CocoaDebug (Extension)
+
++ (void)objcLogWithFile:(const char *)file
+               function:(NSString *)function
+                   line:(NSUInteger)line
+                  color:(UIColor *)color
+                message:(NSString *)format, ... {
+    va_list args;
+    
+    if (format) {
+        va_start(args, format);
+        
+        NSString *wholeMsg = [[NSString alloc] initWithFormat:format arguments:args];
+        
+        va_end(args);
+        
+        va_start(args, format);
+        
+        [LogHelper.shared objcHandleLogWithFile:[NSString stringWithUTF8String:file]  function:function line:line message:wholeMsg color:color];
+        
+        va_end(args);
+    }
+}
+
+@end

--- a/Sources/Core/CocoaDebug.swift
+++ b/Sources/Core/CocoaDebug.swift
@@ -42,26 +42,8 @@ import Foundation
     @objc public static func disable() {
         deinitializationMethod()
     }
-    
-    //MARK: - objcLog() usage only for Objective-C
-    @objc public static func objcHandleLog(_ file: String = #file,
-                                           _ function: String = #function,
-                                           _ line: Int = #line,
-                                           _ message: Any,
-                                           _ color: UIColor) {
-        LogHelper.shared.handleLog(file: file, function: function, line: line, message: message, color: color)
-    }
-    
-    @objc public static func objcLog(_ file: String = #file,
-                                     _ function: String = #function,
-                                     _ line: Int = #line,
-                                     _ message: Any,
-                                     _ color: UIColor) {
-        Swift.print(message)
-        LogHelper.shared.handleLog(file: file, function: function, line: line, message: message, color: color)
-    }
-}
 
+}
 
 //MARK: - swiftLog() usage only for Swift
 public func swiftHandleLog<T>(_ file: String = #file,

--- a/Sources/Logs/LogHelper.swift
+++ b/Sources/Logs/LogHelper.swift
@@ -12,7 +12,7 @@ public class LogHelper: NSObject {
     
     var enable: Bool = true
     
-    static let shared = LogHelper()
+    @objc static let shared = LogHelper()
     private override init() {}
     
     fileprivate func parseFileInfo(file: String?, function: String?, line: Int?) -> String? {
@@ -32,6 +32,20 @@ public class LogHelper: NSObject {
         
         //2.
         let newLog = LogModel(content: stringContent, color: color, fileInfo: fileInfo)
+        LogStoreManager.shared.addLog(newLog)
+        
+        NotificationCenter.default.post(name: NSNotification.Name("refreshLogs_CocoaDebug"), object: nil, userInfo: nil)
+    }
+    
+    @objc func objcHandleLog(file: String?, function: String?, line: Int, message: String, color: UIColor?) {
+        
+        if enable == false {return}
+        
+        //1.
+        let fileInfo = parseFileInfo(file: file, function: function, line: line)
+        
+        //2.
+        let newLog = LogModel(content: message, color: color, fileInfo: fileInfo)
         LogStoreManager.shared.addLog(newLog)
         
         NotificationCenter.default.post(name: NSNotification.Name("refreshLogs_CocoaDebug"), object: nil, userInfo: nil)

--- a/Sources/Logs/LogHelper.swift
+++ b/Sources/Logs/LogHelper.swift
@@ -22,24 +22,23 @@ public class LogHelper: NSObject {
 
     func handleLog(file: String?, function: String?, line: Int?, message: Any..., color: UIColor?) {
         
-        if enable == false {return}
-        
-        //1.
-        let fileInfo = parseFileInfo(file: file, function: function, line: line)
         let stringContent = message.reduce("") { result, next -> String in
             return "\(result)\(result.count > 0 ? " " : "")\(next)"
         }
         
-        //2.
-        let newLog = LogModel(content: stringContent, color: color, fileInfo: fileInfo)
-        LogStoreManager.shared.addLog(newLog)
-        
-        NotificationCenter.default.post(name: NSNotification.Name("refreshLogs_CocoaDebug"), object: nil, userInfo: nil)
+        commonHandleLog(file: file, function: function, line: (line ?? 0), message: stringContent, color: color)
     }
     
     @objc func objcHandleLog(file: String?, function: String?, line: Int, message: String, color: UIColor?) {
         
-        if enable == false {return}
+        commonHandleLog(file: file, function: function, line: line, message: message, color: color)
+    }
+    
+    private func commonHandleLog(file: String?, function: String?, line: Int, message: String, color: UIColor?) {
+        
+        guard enable else {
+            return
+        }
         
         //1.
         let fileInfo = parseFileInfo(file: file, function: function, line: line)


### PR DESCRIPTION
Fix #33 

原来不支持的原因在于宏定义写法将参数 message 定义为一个变量，而实际上想要传入的是多个参数。由于 swift 下的带有多参数特性的方法无法暴露给 OC 调用，所以，采用 category 的方式，解决多参数传递问题。