### PR TITLE
Supports for the app window with `UIScene` on iOS 13+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,12 @@ before_install:
   - brew install gcc || brew link --overwrite gcc
   - brew upgrade
   - brew outdated xctool || brew upgrade xctool
-osx_image: xcode10.2
+osx_image: xcode11.3
 language: objective-c
 xcode_project: Example_Swift.xcodeproj
 xcode_scheme: Example_Swift
 xcode_sdk: iphonesimulator
 script:
-  - xcodebuild -project Example_Swift.xcodeproj -scheme Example_Swift -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone X,OS=11.4' build test
+  - xcodebuild -project Example_Swift.xcodeproj -scheme Example_Swift -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone X,OS=13.3' build test
 after_success:
   - bash <(curl -s https://codecov.io/bash) -J 'Example_Swift' -t 592f3d0c-a304-44a1-b99e-5ea37f78ce9d

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ xcode_project: Example_Swift.xcodeproj
 xcode_scheme: Example_Swift
 xcode_sdk: iphonesimulator
 script:
-  - xcodebuild -project Example_Swift.xcodeproj -scheme Example_Swift -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone X,OS=13.3' build test
+  - xcodebuild -project Example_Swift.xcodeproj -scheme Example_Swift -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 11,OS=13.3' build test
 after_success:
   - bash <(curl -s https://codecov.io/bash) -J 'Example_Swift' -t 592f3d0c-a304-44a1-b99e-5ea37f78ce9d

--- a/Example_Swift.xcodeproj/project.pbxproj
+++ b/Example_Swift.xcodeproj/project.pbxproj
@@ -7,8 +7,6 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		38053E532368460F00AA04A6 /* RevealServer.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 38053E522368460F00AA04A6 /* RevealServer.framework */; };
-		38053E542368460F00AA04A6 /* RevealServer.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 38053E522368460F00AA04A6 /* RevealServer.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		383CB06221E5F58500398720 /* index2.html in Resources */ = {isa = PBXBuildFile; fileRef = 383CB06121E5F58500398720 /* index2.html */; };
 		3849FEA521E5E1DD00662E95 /* index.html in Resources */ = {isa = PBXBuildFile; fileRef = 3849FEA421E5E1DD00662E95 /* index.html */; };
 		3875C6F8228F1A3A00F6B626 /* UIWebViewTestController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3875C6F7228F1A3A00F6B626 /* UIWebViewTestController.swift */; };
@@ -613,7 +611,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				38053E542368460F00AA04A6 /* RevealServer.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -621,7 +618,6 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
-		38053E522368460F00AA04A6 /* RevealServer.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = RevealServer.framework; path = "../../Library/Application Support/Reveal/RevealServer/iOS/RevealServer.framework"; sourceTree = "<group>"; };
 		383CB06121E5F58500398720 /* index2.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = index2.html; sourceTree = "<group>"; };
 		3849FEA421E5E1DD00662E95 /* index.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = index.html; sourceTree = "<group>"; };
 		3875C6F7228F1A3A00F6B626 /* UIWebViewTestController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UIWebViewTestController.swift; sourceTree = "<group>"; };
@@ -1012,7 +1008,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				38053E532368460F00AA04A6 /* RevealServer.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1426,7 +1421,6 @@
 		38B5614C21CCC4CB00BB276A /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				38053E522368460F00AA04A6 /* RevealServer.framework */,
 				38B5614D21CCC4CB00BB276A /* WebKit.framework */,
 			);
 			name = Frameworks;

--- a/Sources/Window/_WindowHelper.swift
+++ b/Sources/Window/_WindowHelper.swift
@@ -10,23 +10,35 @@ import UIKit
 
 public class _WindowHelper: NSObject {
     public static let shared = _WindowHelper()
-    
-    var window: CocoaDebugWindow?
+
+    let window: CocoaDebugWindow
     var displayedList = false
     lazy var vc = CocoaDebugViewController()
-    
+
     private override init() {
         self.window = CocoaDebugWindow(frame: UIScreen.main.bounds)
         // This is for making the window not to effect the StatusBarStyle
-        self.window?.bounds.size.height = UIScreen.main.bounds.height.nextDown
+        self.window.bounds.size.height = UIScreen.main.bounds.height.nextDown
         super.init()
     }
 
     public func enable() {
-        if self.window?.rootViewController != self.vc {
-            self.window?.rootViewController = self.vc
-            self.window?.delegate = self
-            self.window?.isHidden = false
+        if #available(iOS 13.0, *) {
+            if self.window.windowScene?.activationState != .foregroundActive {
+                for scene in UIApplication.shared.connectedScenes {
+                    if scene.activationState == .foregroundActive,
+                        let windowScene = scene as? UIWindowScene {
+                        self.window.windowScene = windowScene
+                        break
+                    }
+                }
+            }
+        }
+
+        if self.window.rootViewController != self.vc {
+            self.window.rootViewController = self.vc
+            self.window.delegate = self
+            self.window.isHidden = false
             _WHDebugFPSMonitor.sharedInstance()?.startMonitoring()
             _WHDebugMemoryMonitor.sharedInstance()?.startMonitoring()
             _WHDebugCpuMonitor.sharedInstance()?.startMonitoring()
@@ -34,10 +46,10 @@ public class _WindowHelper: NSObject {
     }
 
     public func disable() {
-        if self.window?.rootViewController != nil {
-            self.window?.rootViewController = nil
-            self.window?.delegate = nil
-            self.window?.isHidden = true
+        if self.window.rootViewController != nil {
+            self.window.rootViewController = nil
+            self.window.delegate = nil
+            self.window.isHidden = true
             _WHDebugFPSMonitor.sharedInstance()?.stopMonitoring()
             _WHDebugMemoryMonitor.sharedInstance()?.stopMonitoring()
             _WHDebugCpuMonitor.sharedInstance()?.stopMonitoring()


### PR DESCRIPTION
Set the active `windowScene ` for `CocoaDebugWindow ` if needed while displaying the debug window on iOS 13 or later.